### PR TITLE
Fix deployment message and timeAgo extraction issues

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -88,9 +88,9 @@ export const deployCommand = commands.registerCommand('surge-volt.deploy', async
         commands.executeCommand('surge-volt.refresh-domain-list');
         const action = await window.showInformationMessage(`Successfully deployed "${projectName}" project on surge`, 'Open', 'Copy', 'Close');
         if (action === 'Open') {
-            env.openExternal(Uri.parse(`http://${domainName}`));
+            env.openExternal(Uri.parse(`http://${domainName}.surge.sh`));
         } else if (action === 'Copy') {
-            env.clipboard.writeText(`http://${domainName}`);
+            env.clipboard.writeText(`http://${domainName}.surge.sh`);
         }
     }
 

--- a/src/services/surgeService.ts
+++ b/src/services/surgeService.ts
@@ -199,7 +199,7 @@ function extractDomainData(input: string): SurgeDomain[] {
         return new SurgeDomain(
             els[0], // id
             els[0].replace('.surge.sh', ''), // hostname
-            `${els[2]} ${els[3]} ${els[4]}`, //timeAgo
+            `${els[1]} ${els[2]} ${els[3]}`, //timeAgo
         );
     });
 


### PR DESCRIPTION
Append '.surge.sh' to the domain URL in the deployment success message and correct the extraction of the timeAgo value in the extractDomainData function.
Fixes #7